### PR TITLE
Encode URL Parameters

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -30,7 +30,7 @@ app.controller('controller', function($scope, $http, $location) {
       $scope.feed = data.rss.channel;
       var queryParams = Object.keys(config.params || {}).reduce((array, key) => {
         if (config.params[key]) {
-          array.push(key + '=' + config.params[key]);
+          array.push(key + '=' + encodeURIComponent(config.params[key]));
         }
         return array;
       }, []);


### PR DESCRIPTION
If you use a complex regex such as `v[0-9]+$` the generated and displayed URL does not escape the special characters in the URL.