### PR TITLE
Switch feed title order

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ app.listen(3000, function () {
 
 function formatRSS(repo, user, images) {
   var feed = new RSS({
-    title: 'Docker Hub Images: ' + repo.user + '/' + repo.name,
+    title: repo.user + '/' + repo.name + ' | Docker Hub Images',
     description: repo.description,
     site_url: 'https://hub.docker.com/r/' + repo.user + '/' + repo.name,
     image_url: user.gravatar_url


### PR DESCRIPTION
place the user and repo names at the beginning of the feed title so even if the title is truncated, the unique information can be seen