### PR TITLE
Add specifics to image url

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ function formatRSS(repo, user, images) {
   images.forEach(image => {
     feed.item({
       title: repo.user + '/' + repo.name + ':' + image.name,
-      url: 'https://hub.docker.com/r/' + repo.user + '/' + repo.name,
+      url: 'https://hub.docker.com/r/' + repo.user + '/' + repo.name + '/tags?name=' + image.name,
       guid: image.id + '-' + new Date(image.last_updated).getTime(),
       date: new Date(image.last_updated)
     });


### PR DESCRIPTION
There does not appear to be a URL for a specific tag (only a tag and its specific image).
There is, however, a search page for tags that can at least get the user one click away from the specific page.

So for the current `latest` tag, the specific url is [long](https://hub.docker.com/layers/theconnman/docker-hub-rss/latest/images/sha256-9c7f74d19be4c091c553ea1155475b11101b68092794a63bb80ca9a15e40fd6e), but the search page version is [shorter and simpler](https://hub.docker.com/r/theconnman/docker-hub-rss/tags?name=latest)