### PR TITLE
introduce env var to limit the number of tags being fetched

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ vercel dev
 
 - **FLUENTD_HOST** (Optional) Fluent host for logging
 - **FLUENTD_TAGS** (Optional) Add FluentD context tags (format is tag:value,tag2:value2)
+- **TAGS_FETCH_LIMIT** (Optional) Fetch only the given number of tags (before being filtered). Useful for reducing traffic and avoiding possible time-outs.

--- a/api/[username]/[repository].js
+++ b/api/[username]/[repository].js
@@ -41,7 +41,7 @@ async function getTagsRecursive(username, repository, page, tags) {
   const tagsPage = await dockerHubAPI.tags(username, repository, {
     page
   });
-  if ("length" in (tagsPage.results || tagsPage) === false || (tagsPage.results || tagsPage).length === 0) {
+  if ("length" in (tagsPage.results || tagsPage) === false || (tagsPage.results || tagsPage).length === 0 || tags.length >= process.env.TAGS_FETCH_LIMIT) {
     return Promise.resolve(tags);
   }
   return getTagsRecursive(username, repository, page + 1, tags.concat((tagsPage.results || tagsPage)));


### PR DESCRIPTION
Rationale: I'm using this app to get notified about newly released tags of various images. So the current behavior of fetching ***all*** tags is not needed in my case and causes just a lot of traffic. Furthermore, on large repos, querying the app may cause a time-out and – only due to the fact that the `docker-hub-api` package caches its results for 5 minutes by default – querying the app again during that period will actually return any results.

This PR introduces an env var `TAGS_FETCH_LIMIT` to limit the number of tags being fetched (before being filtered). Let me know if its name is fine for you.