### PR TITLE
fixed endless loop

### DIFF
--- a/api/[username]/[repository].js
+++ b/api/[username]/[repository].js
@@ -41,7 +41,7 @@ async function getTagsRecursive(username, repository, page, tags) {
   const tagsPage = await dockerHubAPI.tags(username, repository, {
     page
   });
-  if ((tagsPage.results || tagsPage).length === 0) {
+  if ("length" in (tagsPage.results || tagsPage) === false || (tagsPage.results || tagsPage).length === 0) {
     return Promise.resolve(tags);
   }
   return getTagsRecursive(username, repository, page + 1, tags.concat((tagsPage.results || tagsPage)));


### PR DESCRIPTION
Fixed an endless loop when the result of dockerHubAPI.tags() is not an array.

The loop leads to exceeded rate limit on docker hubs search api: https://github.com/docker/hub-feedback/issues/2252